### PR TITLE
Added Metadata Support into the SecretManagement Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a [SecretManagement](https://github.com/PowerShell/SecretManagement) ext
 is built into Pleasant Password Server.
 
 > **NOTE: This is not a maintained project and it's specifically not maintained _by_ the creators of Pleasant Password Server.**
-> **I work on it in my free time because I use Pleasant Password Server in our company.**
+> **I work on it in my free time because I use Pleasant Password Server in my company.**
 
 ## Prerequisites
 
-* [PowerShell](https://github.com/PowerShell/PowerShell)
+* [PowerShell](https://github.com/PowerShell/PowerShell) (It is also usable with PowerShell 5.1)
 * The [SecretManagement](https://github.com/PowerShell/SecretManagement) PowerShell module
 
 You can get the `SecretManagement` module from the PowerShell Gallery:
@@ -122,25 +122,21 @@ A PSCredential Object with your credentials for your Pleasant Password Server
 
 If you want to add or change a secret you can change the following metadata:
 
-| Field Name       | Type         |
-| ---------------- | ------------ |
-| CustomUserFields | Hashtable    |
-| Attachments      | Hashtable    |
-| Tags             | Hashtable    |
-| Name             | String       |
-| Username         | String       |
-| Password         | SecureString |
-| Url              | String       |
-| Notes            | String       |
-| FolderName       | String       |
-| Created          | DateTime     |
-| Modified         | DateTime     |
-| Expires          | DateTime     |
+| Field Name       | Type      |
+| ---------------- | --------- |
+| CustomUserFields | Hashtable |
+| Tags             | Hashtable |
+| Name             | String    |
+| Username         | String    |
+| Password         | String    |
+| Url              | String    |
+| Notes            | String    |
+| FolderName       | String    |
+| Created          | DateTime  |
+| Modified         | DateTime  |
+| Expires          | DateTime  |
 
 > **You do not have to provide the whole array.**
-> If you want to change the folder of the secret you have to provide
-> the folder before the folder and then the new folder to prevent
-> moving It to the wrong folder.
 
 You can provide this hashtable to `Set-Secret` and `Set-SecretInfo`.
 
@@ -153,20 +149,20 @@ $Metadata = @{
         CF2=2
         CF1=1
     }
-    Tags             = {
+    Tags             = @(
         @{
-            Name=Tag1
+            Name="Tag1"
          },
         @{
-            Name=Tag2
+            Name="Tag2"
          }
-    }
+    )
     Name             = 'MetadataTest'
     Username         = 'admin'
-    Password         = (ConvertTo-SecureString -Text 'NewPassword' -AsPlainText -Force)
+    Password         = 'Password'
     Url              = 'http://www.google.de'
     Notes            = 'This is the metadata test'
-    FolderName       = 'Folder/NewFolder'
+    FolderName       = 'Root/NewFolder'
     Created          = (Get-Date)
     Modified         = (Get-Date)
     Expires          = (Get-Date)

--- a/README.md
+++ b/README.md
@@ -117,3 +117,59 @@ Stores the credentials for Pleasant Password Server to disk
 ##### [PSCredential] Credential
 
 A PSCredential Object with your credentials for your Pleasant Password Server
+
+## Metadata Array
+
+If you want to add or change a secret you can change the following metadata:
+
+| Field Name       | Type         |
+| ---------------- | ------------ |
+| CustomUserFields | Hashtable    |
+| Attachments      | Hashtable    |
+| Tags             | Hashtable    |
+| Name             | String       |
+| Username         | String       |
+| Password         | SecureString |
+| Url              | String       |
+| Notes            | String       |
+| FolderName       | String       |
+| Created          | DateTime     |
+| Modified         | DateTime     |
+| Expires          | DateTime     |
+
+> **You do not have to provide the whole array.**
+> If you want to change the folder of the secret you have to provide
+> the folder before the folder and then the new folder to prevent
+> moving It to the wrong folder.
+
+You can provide this hashtable to `Set-Secret` and `Set-SecretInfo`.
+
+An Example Metadata Array is:
+
+```powershell
+
+$Metadata = @{
+    CustomUserFields =  @{
+        CF2=2
+        CF1=1
+    }
+    Tags             = {
+        @{
+            Name=Tag1
+         },
+        @{
+            Name=Tag2
+         }
+    }
+    Name             = 'MetadataTest'
+    Username         = 'admin'
+    Password         = (ConvertTo-SecureString -Text 'NewPassword' -AsPlainText -Force)
+    Url              = 'http://www.google.de'
+    Notes            = 'This is the metadata test'
+    FolderName       = 'Folder/NewFolder'
+    Created          = (Get-Date)
+    Modified         = (Get-Date)
+    Expires          = (Get-Date)
+}
+
+```

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/ConvertTo-ReadOnlyDictionary.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/ConvertTo-ReadOnlyDictionary.ps1
@@ -1,0 +1,23 @@
+using namespace System.Collections.ObjectModel
+using namespace System.Collections.Generic
+function ConvertTo-ReadOnlyDictionary
+{
+    <#
+        .SYNOPSIS
+        Converts a hashtable to a ReadOnlyDictionary[String,Object]. Needed for SecretInformation
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [hashtable]
+        $hashtable
+    )
+    process
+    {
+        $dictionary = [SortedDictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+        $hashtable.GetEnumerator().foreach{
+            $dictionary[$_.Name] = $_.Value
+        }
+        [ReadOnlyDictionary[string, object]]::new($dictionary)
+    }
+}

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-Children.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-Children.ps1
@@ -1,0 +1,61 @@
+function Get-Children
+{
+
+    <#
+    .SYNOPSIS
+        Lists all Folders an their credentials recursive.
+    .DESCRIPTION
+        Lists all Folders an their credentials recursive.
+    .PARAMETER Folder
+        The current folder in the folderstructure
+    .EXAMPLE
+        PS C:\> Get-Children -Folder $f
+        Lists all Folders an their credentials recursive.
+    .INPUTS
+        System.Object
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject[]
+    .NOTES
+        Author: Constantin Hager
+        Date: 2021-03-17
+    #>
+
+    param (
+        [Parameter(Mandatory)]
+        [System.Object]
+        $Folder
+    )
+
+    if ($null -ne $Folder)
+    {
+        $returnList = New-object 'System.Collections.Generic.List[System.Object]'
+
+        if ($Folder.Name -eq "Root")
+        {
+            # Root Folder + Credentials
+            $row = [PSCustomObject]@{
+                Folder      = $Folder.Name
+                Credentials = $Folder.Credentials
+            }
+
+            $returnlist.add($row)
+        }
+
+        foreach ($subfolder in $Folder.Children)
+        {
+            # Subfolders + Credentials
+            $row = [PSCustomObject]@{
+                Folder      = [string]::Concat($Folder.Name, '/', $subfolder.Name)
+                Credentials = $subfolder.Credentials
+            }
+
+            $returnlist.add($row)
+
+            foreach ($f in $subfolder)
+            {
+                Get-Children -Folder $f
+            }
+        }
+    }
+    return $returnlist
+}

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-Children.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-Children.ps1
@@ -35,6 +35,7 @@ function Get-Children
             # Root Folder + Credentials
             $row = [PSCustomObject]@{
                 Folder      = $Folder.Name
+                FolderID    = $Folder.Id
                 Credentials = $Folder.Credentials
             }
 
@@ -46,6 +47,7 @@ function Get-Children
             # Subfolders + Credentials
             $row = [PSCustomObject]@{
                 Folder      = [string]::Concat($Folder.Name, '/', $subfolder.Name)
+                FolderID    = $subfolder.Id
                 Credentials = $subfolder.Credentials
             }
 

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFolder.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFolder.ps1
@@ -1,0 +1,57 @@
+function Get-SecretFolder
+{
+    <#
+    .SYNOPSIS
+        Get the folderstructure for a single secret
+    .DESCRIPTION
+        Get the folderstructure for a single secret
+    .EXAMPLE
+        $param = @{
+            ServerURL = '<your server url>'
+            Token     = '<your token>'
+            GroupID   = '<your group id>'
+        }
+
+        PS C:\> Get-SecretFolder @param
+        Get the folderstructure for a single secret
+    .INPUTS
+        System.String,
+        System.String
+        System.String
+    .OUTPUTS
+        System.String[]
+    .NOTES
+        Author: Constantin Hager
+        Date: 2021-03-17
+    #>
+
+    param
+    (
+        $ServerURL,
+        $Token,
+        $GroupID
+    )
+
+    if ($GroupID -eq "00000000-0000-0000-0000-000000000000")
+    {
+        $FolderString = 'Root'
+        return
+    }
+
+    $headers = @{
+        "Accept"        = "application/json"
+        "Authorization" = "$Token"
+    }
+
+    $Params = @{
+        Method      = 'GET'
+        Uri         = "$ServerURL/api/v5/rest/folders/$($GroupId)?recurseLevel=0"
+        Headers     = $headers
+        ContentType = 'application/json'
+    }
+    $FolderMetadata = Invoke-RestMethod @Params
+
+    $Folderstring = [string]::Concat($FolderMetadata.Name, '/', $FolderString)
+    Get-SecretFolder -ServerURL $ServerURL -Token $Token -GroupID $FolderMetadata.ParentId
+    return $Folderstring
+}

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFolder.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFolder.ps1
@@ -53,5 +53,5 @@ function Get-SecretFolder
 
     $Folderstring = [string]::Concat($FolderMetadata.Name, '/', $FolderString)
     Get-SecretFolder -ServerURL $ServerURL -Token $Token -GroupID $FolderMetadata.ParentId
-    return $Folderstring
+    return $FolderString
 }

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Get-SecretInfo.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Get-SecretInfo.ps1
@@ -100,6 +100,7 @@ function Get-SecretInfo
                 [DateTime]$Credential.Expires
             }
             FolderName       = $FolderPath[0]
+            Id               = $Folder.FolderID
         } | ConvertTo-ReadOnlyDictionary
 
         return [SecretInformation]::new(
@@ -162,6 +163,7 @@ function Get-SecretInfo
                         [DateTime]$Credential.Expires
                     }
                     FolderName       = $Folder.Folder
+                    Id               = $Folder.FolderID
                 } | ConvertTo-ReadOnlyDictionary
 
                 [SecretInformation]::new(

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Get-SecretInfo.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Get-SecretInfo.ps1
@@ -27,53 +27,148 @@ function Get-SecretInfo
         "Authorization" = "$Token"
     }
 
-    $body = @{
-        "search" = "$Filter"
-    }
-
     $PasswordServerURL = [string]::Concat($AdditionalParameters.ServerURL, ":", $AdditionalParameters.Port)
 
-    $Secrets = Invoke-RestMethod -method post -Uri "$PasswordServerURL/api/v5/rest/search" -body (ConvertTo-Json $body) -Headers $headers -ContentType 'application/json'
-    $id = $Secrets.Credentials.id
+    $Filter = $PSBoundParameters.Filter
 
-    if ($id.Count -gt 1)
+    if ($Filter -ne '*')
     {
-        throw "Multiple ambiguous entries found for $Name, please remove the duplicate entry"
-    }
+        $body = @{
+            "search" = "$Filter"
+        }
 
-    if ($null -eq $id)
+        $Secrets = Invoke-RestMethod -method post -Uri "$PasswordServerURL/api/v5/rest/search" -body (ConvertTo-Json $body) -Headers $headers -ContentType 'application/json'
+        $id = $Secrets.Credentials.id
+
+        if ($id.Count -gt 1)
+        {
+            throw "Multiple ambiguous entries found for $Name, please remove the duplicate entry"
+        }
+
+        if ($null -eq $id)
+        {
+            throw "No secret with $Name is found"
+        }
+
+        $Params = @{
+            Method      = 'GET'
+            Uri         = "$PasswordServerURL/api/v5/rest/Entries/$id"
+            Headers     = $headers
+            ContentType = 'application/json'
+        }
+
+        $CredentialMetadata = Invoke-RestMethod @Params
+
+        $Params = @{
+            Method      = 'GET'
+            Uri         = "$PasswordServerURL/api/v5/rest/folders/$($CredentialMetadata.GroupId)?recurseLevel=0"
+            Headers     = $headers
+            ContentType = 'application/json'
+        }
+        $FolderMetadata = Invoke-RestMethod @Params
+
+        $Name = $CredentialMetadata.Name
+
+        [ReadOnlyDictionary[String, Object]]$metadata = [ordered]@{
+            CustomUserFields = $CredentialMetadata.CustomUserFields
+            Attachments      = $CredentialMetadata.Attachments
+            Tags             = $CredentialMetadata.Tags
+            Url              = $CredentialMetadata.Url
+            Notes            = $CredentialMetadata.Notes
+            Created          = [DateTime]$CredentialMetadata.Created
+            Modified         = [DateTime]$CredentialMetadata.Modified
+            Expires          = [DateTime]$CredentialMetadata.Expires
+            FolderName       = $FolderMetadata.Name
+        } | ConvertTo-ReadOnlyDictionary
+
+        return [SecretInformation]::new(
+            $Name,
+            [SecretType]::PSCredential,
+            $VaultName,
+            $metadata
+        )
+    }
+    else
     {
-        throw "No secret with $Name is found"
+        #TODO: Add Folder recursion for retrieving Credentials in subfolders
+
+        $Params = @{
+            Method      = 'GET'
+            Uri         = "$PasswordServerURL/api/v5/rest/folders/"
+            Headers     = $headers
+            ContentType = 'application/json'
+        }
+
+        $AllFolders = Invoke-RestMethod @Params
+
+        [Object[]]$secretInfoResult = foreach ($Credential in $AllFolders)
+        {
+            # Credentials
+            $AllCredentials = $AllFolders.Credentials
+
+            foreach ($Credential in $AllCredentials)
+            {
+                $Name = $Credential.Name
+
+                $Params = @{
+                    Method      = 'GET'
+                    Uri         = "$PasswordServerURL/api/v5/rest/folders/$($Credential.GroupId)?recurseLevel=0"
+                    Headers     = $headers
+                    ContentType = 'application/json'
+                }
+                $FolderMetadata = Invoke-RestMethod @Params
+
+                [ReadOnlyDictionary[String, Object]]$metadata = [ordered]@{
+                    CustomUserFields = $Credential.CustomUserFields
+                    Attachments      = $Credential.Attachments
+                    Tags             = $Credential.Tags
+                    Url              = $Credential.Url
+                    Notes            = $Credential.Notes
+                    Created          = if ([string]::IsNullOrWhiteSpace($Credential.Created))
+                    {
+                        ''
+                    }
+                    else
+                    {
+                        [DateTime]$Credential.Created
+                    }
+                    Modified         = if ([string]::IsNullOrWhiteSpace($Credential.Modified))
+                    {
+                        ''
+                    }
+                    else
+                    {
+                        [DateTime]$Credential.Modified
+                    }
+                    Expires          = if ([string]::IsNullOrWhiteSpace($Credential.Expires))
+                    {
+                        ''
+                    }
+                    else
+                    {
+                        [DateTime]$Credential.Expires
+                    }
+                    FolderName       = $FolderMetadata.Name
+                } | ConvertTo-ReadOnlyDictionary
+
+                [SecretInformation]::new(
+                    $Name,
+                    [SecretType]::PSCredential,
+                    $VaultName,
+                    $metadata
+                )
+
+            }
+        }
+
+        [Object[]]$sortedInfoResult = $secretInfoResult | Sort-Object -Unique -Property Name
+        if ($sortedInfoResult.count -lt $secretInfoResult.count)
+        {
+            $nonUniqueFilteredRecords = Compare-Object $sortedInfoResult $secretInfoResult -Property Name | Where-Object SideIndicator -eq '=>'
+            Write-Warning "Vault ${VaultName}: Entries with non-unique titles were detected, the duplicates were filtered out.)"
+            Write-Warning "Vault ${VaultName}: Filtered Non-Unique Titles: $($nonUniqueFilteredRecords.Name -join ', ')"
+        }
+
+        return $secretInfoResult
     }
-
-    $Params = @{
-        Method      = 'GET'
-        Uri         = "$PasswordServerURL/api/v5/rest/Entries/$id"
-        Headers     = $headers
-        ContentType = 'application/json'
-    }
-
-    $CredentialMetadata = Invoke-RestMethod @Params
-
-    # TODO: Datemagic
-    # TODO: Only provide Filename and Size
-    # TODO: Return Foldername for GroupID
-    [ReadOnlyDictionary[String, Object]]$metadata = [ordered]@{
-        CustomUserFields = $CredentialMetadata.CustomUserFields
-        Attachments      = $CredentialMetadata.Attachments
-        Tags             = $CredentialMetadata.Tags
-        Url              = $CredentialMetadata.Url
-        Notes            = $CredentialMetadata.Notes
-        Created          = $CredentialMetadata.Created
-        Modified         = $CredentialMetadata.Modified
-        Expires          = $CredentialMetadata.Expires
-
-    } | ConvertTo-ReadOnlyDictionary
-
-    return [SecretInformation]::new(
-        $Filter,
-        [SecretType]::PSCredential,
-        $VaultName,
-        $metadata
-    )
 }

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Set-Secret.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Set-Secret.ps1
@@ -36,38 +36,70 @@ function Set-Secret
 
     $PasswordServerURL = [string]::Concat($AdditionalParameters.ServerURL, ":", $AdditionalParameters.Port)
 
-    $RootFolderid = Invoke-RestMethod -Uri "$PasswordServerURL/api/v5/rest/folders/root" -Headers $headers -ContentType 'application/json'
+    if($Metadata.FolderName -eq "Root")
+    {
+        $splat = @{
+            Uri = "$PasswordServerURL/api/v5/rest/folders/root"
+            Headers = $headers
+            ContentType = 'application/json'
+        }
+        $FolderID = Invoke-RestMethod @splat
+    }
+    else
+    {
+        $Params = @{
+            Method      = 'GET'
+            Uri         = "$PasswordServerURL/api/v5/rest/folders/"
+            Headers     = $headers
+            ContentType = 'application/json'
+        }
+
+        $AllFolders = Invoke-RestMethod @Params
+        $PPSStructure = Get-Children -Folder $AllFolders
+
+        if($Metadata.FolderName.Split('/').Count -gt 2)
+        {
+            $Split = $Metadata.FolderName.Split('/')
+            $Path1 = $Split[$Split.Length-2]
+            $Path2 = $Split[$Split.Length-1]
+            $FullPath = [string]::Concat($Path1, "/", $Path2)
+        }
+        else
+        {
+            $FullPath = $Metadata.FolderName
+        }
+
+        $FolderID = $PPSStructure | Where-Object {$_.Folder -eq $FullPath} | Select-Object -ExpandProperty FolderID
+    }
 
 
     if ($Secret -is [System.Management.Automation.PSCredential])
     {
         $body_add = [ordered]@{
-            "CustomUserFields"        = @{}
-            "CustomApplicationFields" = @{}
-            "Tags"                    = @()
+            "CustomUserFields"        = $Metadata.CustomUserFields
+            "Tags"                    = $Metadata.Tags
             "Name"                    = $Name
             "UserName"                = $Secret.UserName
             "Password"                = $Secret.GetNetworkCredential().Password
-            "Url"                     = ""
-            "Notes"                   = ""
-            "GroupId"                 = $RootFolderid
-            "Expires"                 = $null
+            "Url"                     = $Metadata.Url
+            "Notes"                   = $Metadata.Notes
+            "GroupId"                 = $FolderID
+            "Expires"                 = $Metadata.Expires
         }
     }
 
     if ($Secret -is [System.Security.SecureString])
     {
         $body_add = [ordered]@{
-            "CustomUserFields"        = @{}
-            "CustomApplicationFields" = @{}
-            "Tags"                    = @()
+            "CustomUserFields"        = $Metadata.CustomUserFields
+            "Tags"                    = $Metadata.Tags
             "Name"                    = $Name
             "UserName"                = ""
             "Password"                = ConvertFrom-SecureString -SecureString $Secret
-            "Url"                     = ""
-            "Notes"                   = ""
-            "GroupId"                 = $RootFolderid
-            "Expires"                 = $null
+            "Url"                     = $Metadata.Url
+            "Notes"                   = $Metadata.Notes
+            "GroupId"                 = $FolderID
+            "Expires"                 = $Metadata.Expires
         }
     }
 

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Set-Secret.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Set-Secret.ps1
@@ -14,6 +14,10 @@ function Set-Secret
         [string]
         $VaultName,
 
+        [Parameter()]
+        [hashtable]
+        $Metadata,
+
         [Parameter(Mandatory)]
         [hashtable]
         $AdditionalParameters

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Set-SecretInfo.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Set-SecretInfo.ps1
@@ -11,9 +11,57 @@ function Set-SecretInfo
         $Metadata,
 
         [Parameter(Mandatory)]
+        [hashtable]
+        $AdditionalParameters,
+
+        [Parameter(Mandatory)]
         [string]
         $VaultName
     )
 
-    throw [System.NotImplementedException]
+    trap
+    {
+        Write-VaultError -ErrorRecord $_
+    }
+
+    $Token = Invoke-LoginToPleasant -AdditionalParameters $AdditionalParameters
+    $headers = @{
+        "Accept"        = "application/json"
+        "Authorization" = "$Token"
+    }
+
+    $PasswordServerURL = [string]::Concat($AdditionalParameters.ServerURL, ":", $AdditionalParameters.Port)
+
+    $Params = @{
+        Method      = 'GET'
+        Uri         = "$PasswordServerURL/api/v5/rest/folders/"
+        Headers     = $headers
+        ContentType = 'application/json'
+    }
+
+    $AllFolders = Invoke-RestMethod @Params
+    $PPSStructure = Get-Children -Folder $AllFolders
+
+    # Get the secret
+    $Secret = $PPSStructure.Credentials | Where-Object { $_.Name -eq $Name }
+
+    if ($null -eq $Secret)
+    {
+        throw "No secret with $Name is found"
+    }
+
+    if ($Secret.Count -gt 1)
+    {
+        throw "Multiple ambiguous entries found for $Name, please remove the duplicate entry"
+    }
+
+    #TODO: If FolderName is there get the id for the folder and write it back to the metadata hashtable
+    #TODO: Compare the current Secret with the metadata array
+    #TODO: If Metadata Array contains the Password convert It back to plaintext
+    #TODO: Write the changes back to the secret
+
+    # Get the folder ID
+    #$FolderId = $PPSStructure | Where-Object { $_.Id -eq $Metadata.FolderName }
+
+
 }

--- a/SecretManagement.PleasantPasswordServer.Extension/Public/Set-SecretInfo.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Public/Set-SecretInfo.ps1
@@ -1,0 +1,19 @@
+function Set-SecretInfo
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $Metadata,
+
+        [Parameter(Mandatory)]
+        [string]
+        $VaultName
+    )
+
+    throw [System.NotImplementedException]
+}

--- a/SecretManagement.PleasantPasswordServer.Extension/SecretManagement.PleasantPasswordServer.Extension.psd1
+++ b/SecretManagement.PleasantPasswordServer.Extension/SecretManagement.PleasantPasswordServer.Extension.psd1
@@ -1,5 +1,5 @@
 @{
     ModuleVersion     = '0.2.0'
     RootModule        = '.\SecretManagement.PleasantPasswordServer.Extension.psm1'
-    FunctionsToExport = @('Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault')
+    FunctionsToExport = @('Set-Secret', 'Get-Secret', 'Remove-Secret', 'Get-SecretInfo', 'Test-SecretVault', 'Set-SecretInfo')
 }


### PR DESCRIPTION
Implemented a better Get-SecretInfo: All Secrets with metadata are now listed if you do not provide a name.
Added Support for adding metadata to the SecretManagement Extension

Closes #15 