### PR TITLE
added login token re-use

### DIFF
--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
@@ -1,15 +1,56 @@
 function Get-SecretFile
 {
-    $FilePath = Join-Path -Path $env:TEMP -ChildPath "PleasantCred.xml"
+    [CmdletBinding()]
+    Param(
+        
+        [Parameter(Mandatory, ParameterSetName = "VaultCredential")]
+        [Switch]$VaultCredential,
 
-    if (Test-Path -Path $FilePath)
+        [Parameter(Mandatory, ParameterSetName = "LoginToken")]
+        [Switch]$LoginToken
+
+    )
+
+    Switch ($PSCmdlet.ParameterSetName)
     {
-        $Credential = Import-Clixml -Path $FilePath
-        Write-Verbose "Credentials found for user '$($Credential.Username)'."
-        return $Credential
+
+        "VaultCredential"
+        {
+            $FilePath = Join-Path -Path $env:TEMP -ChildPath "PleasantCred.xml"
+
+            if (Test-Path -Path $FilePath)
+            {
+                $Credential = Import-Clixml -Path $FilePath
+                Write-Verbose "Credentials found for user '$($Credential.Username)'."
+                return $Credential
+            }
+            else
+            {
+                throw "Credential File not found. Please import the module and run New-PleasantCredential to create the file."
+            }
+        }
+
+        "LoginToken"
+        {
+            $FilePath = Join-Path -Path $env:TEMP -ChildPath "PleasantToken.xml"
+
+            if (Test-Path -Path $FilePath)
+            {
+                $SecureToken = Import-Clixml -Path $FilePath
+                Write-Verbose "Login token file found."
+                $Token = [PSCustomObject]@{
+                    "Access_Token" = [System.Net.NetworkCredential]::new('', $SecureToken.Access_Token).Password
+                    "Expires" = $SecureToken.Expires
+                }
+                return $Token
+            }
+            else
+            {
+                Write-Verbose "Login token file not found."
+                return
+            }
+        }
+
     }
-    else
-    {
-        throw "Credential File not found. Please import the module and run New-PleasantCredential to create the file."
-    }
+    
 }

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
@@ -5,6 +5,7 @@ function Get-SecretFile
     if (Test-Path -Path $FilePath)
     {
         $Credential = Import-Clixml -Path $FilePath
+        write-verbose "Credentials found for user '$($Credential.Username)'."
         return $Credential
     }
     else

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Get-SecretFile.ps1
@@ -5,7 +5,7 @@ function Get-SecretFile
     if (Test-Path -Path $FilePath)
     {
         $Credential = Import-Clixml -Path $FilePath
-        write-verbose "Credentials found for user '$($Credential.Username)'."
+        Write-Verbose "Credentials found for user '$($Credential.Username)'."
         return $Credential
     }
     else

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Invoke-LoginToPleasant.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Invoke-LoginToPleasant.ps1
@@ -46,7 +46,7 @@ function Invoke-LoginToPleasant
     }
 
     # Get a token if none already exists or it is expired
-    write-verbose "Generating new login token"
+    Write-Verbose "Generating new login token"
     
     $PasswordServerURL = [string]::Concat($AdditionalParameters.ServerURL, ":", $AdditionalParameters.Port)
 

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Invoke-LoginToPleasant.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Invoke-LoginToPleasant.ps1
@@ -36,12 +36,12 @@ function Invoke-LoginToPleasant
 
     # Check if a login token already exists and is not expired
     if ($null -ne $script:LoginToken){
-            write-verbose "Existing login token found"
+            Write-Verbose "Existing login token found"
         if ((get-date) -lt $script:loginToken.expires){
-            write-verbose "Login token is valid"
+            Write-Verbose "Login token is valid"
             return $Script:loginToken.access_token
         } else {
-            write-verbose "Login token is expired"
+            Write-Verbose "Login token is expired"
         }
     }
 
@@ -68,7 +68,7 @@ function Invoke-LoginToPleasant
     }
 
     # Authenticate to Pleasant Password Server
-    write-verbose $Splat.uri
+    Write-Verbose $Splat.uri
     $JSON = Invoke-WebRequest @splat
 
     if ($null -eq $JSON)
@@ -78,8 +78,12 @@ function Invoke-LoginToPleasant
     else
     {
         # Generate and store JSON token
-        $script:loginToken = ConvertFrom-Json $JSON.Content
-        $script:loginToken | Add-Member -MemberType NoteProperty -Name "expires" -value (get-date).AddSeconds($script:LoginToken.expires_in)
+        $token = ConvertFrom-Json $JSON.Content
+
+        $script:loginToken = [PSCustomObject]@{
+            access_token = $token.access_token
+            expires      = (Get-Date).AddSeconds($token.expires_in)
+        }
 
         return $script:loginToken.access_token
     }

--- a/SecretManagement.PleasantPasswordServer.Extension/Private/Out-SecretFile.ps1
+++ b/SecretManagement.PleasantPasswordServer.Extension/Private/Out-SecretFile.ps1
@@ -1,0 +1,26 @@
+function Out-SecretFile
+{
+    [CmdletBinding()]
+    param (
+        # Parameter help description
+        [Parameter(Mandatory, ParameterSetName = "LoginToken")]
+        [PSCustomObject]
+        $LoginToken
+    )
+
+    Switch ($PSCmdlet.ParameterSetName){
+
+        "LoginToken"
+        {
+            Write-Verbose "Saving login token file to disk"
+            $SecureToken = [PSCustomObject]@{
+                "Access_Token" = ConvertTo-SecureString -String $LoginToken.Access_Token -AsPlainText -Force
+                "Expires" = $LoginToken.Expires
+            }
+            $FilePath = Join-Path -Path $env:TEMP -ChildPath "PleasantToken.xml"
+            $SecureToken | Export-Clixml -Path $FilePath
+        }
+
+    }
+
+}


### PR DESCRIPTION
Hello,

I have the need to access multiple credentials at a time.

I found that when doing this a new OAuth token was generated each time by the modules. This caused multiple login events to be added to the audit log in Pleasant Password Server. It was not a huge issue but I did not like it.

This pull request adds the ability to save the OAuth token into memory to be re-used again for future calls.

Thanks